### PR TITLE
Fix issue 40 config

### DIFF
--- a/CMake/Options.cmake
+++ b/CMake/Options.cmake
@@ -4,6 +4,7 @@ OPTION(ENABLE_SSE "enable SSE4.2 buildin function" ON)
 OPTION(ENABLE_FRAME_POINTER "enable frame pointer on 64bit system with flag -fno-omit-frame-pointer, on 32bit system, it is always enabled" ON)
 OPTION(ENABLE_LIBCPP "using libc++ instead of libstdc++, only valid for clang compiler" OFF)
 OPTION(ENABLE_BOOST "using boost instead of native compiler c++0x support" OFF)
+OPTION(HADOOP_CONFIG_DIR "path to the Hadoop configuration files" "/etc/hadoop/config")
 
 INCLUDE (CheckFunctionExists)
 CHECK_FUNCTION_EXISTS(dladdr HAVE_DLADDR)
@@ -21,6 +22,9 @@ ENDIF(ENABLE_DEBUG STREQUAL ON)
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-strict-aliasing")
+
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHADOOP_CONFIG_DIR='\"${HADOOP_CONFIG_DIR}\"'")
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHADOOP_CONFIG_DIR=\"${HADOOP_CONFIG_DIR}\"")
 
 IF(ENABLE_COVERAGE STREQUAL ON)
     INCLUDE(CodeCoverage)

--- a/bootstrap
+++ b/bootstrap
@@ -18,6 +18,9 @@ default_prefix=${source_dir}/dist
 # Choose the default dependency install prefix
 default_dependency=${DEPENDENCY_INSTALL_PREFIX}
 
+# The default Hadoop configuration directory is /etc/hadoop/conf
+default_hadoop_config_dir="/etc/hadoop/conf"
+
 if [ x"${default_dependency}" = x"" ]; then
     default_dependency="/opt/dependency"
 fi
@@ -33,6 +36,8 @@ Configuration:
                                     ['"${default_prefix}"']
     --dependency=DIRs               specify the dependencies at DIRs, separated by colon 
                                     ['"${default_dependency}"']
+    --hadoop-config-dir=<path>      set path to hadoop config, <path> is path to hadoop config dir
+                                    ['"${default_hadoop_config_dir}"']
     --enable-debug                  enable debug build
     --enable-boost                  force to enable boost
     --enable-coverage               enable build with code coverage support
@@ -63,6 +68,7 @@ Example:
 # Parse arguments
 prefix_dirs="${default_prefix}"
 dependency_dir="${default_dependency}"
+hadoop_config_dir="${default_hadoop_config_dir}"
 build_type="Release"
 enable_boost="OFF"
 enable_coverage="OFF"
@@ -73,6 +79,8 @@ while test $# != 0; do
                 prefix_dirs="$dir";;
     --dependency=*) dir=`arg "$1"`
                 dependency_dir="$dir";;
+    --hadoop-config-dir=*) dir=`arg "$1"`
+                hadoop_config_dir="$dir";;
     --enable-debug) enable_build="ON";;
     --enable-boost) enable_boost="ON";;
     --enable-coverage) enable_coverage="ON";;
@@ -116,7 +124,9 @@ fi
 ${cmake} -DENABLE_DEBUG=${enable_build} -DCMAKE_INSTALL_PREFIX=${prefix_dirs} \
     -DCMAKE_C_COMPILER=${c_compiler} -DCMAKE_CXX_COMPILER=${cxx_compiler} \
     -DCMAKE_PREFIX_PATH=${dependency_dir} -DENABLE_BOOST=${enable_boost} \
-    -DENABLE_COVERAGE=${enable_coverage} -DENABLE_LIBCPP=${enable_clang_lib} ${source_dir} \
+    -DENABLE_COVERAGE=${enable_coverage} -DENABLE_LIBCPP=${enable_clang_lib} \
+    -DHADOOP_CONFIG_DIR=${hadoop_config_dir} \
+    ${source_dir} \
     || die "failed to configure the project"
 
 echo 'bootstrap success. Run "make" to build.'

--- a/src/common/SessionConfig.cpp
+++ b/src/common/SessionConfig.cpp
@@ -141,6 +141,8 @@ SessionConfig::SessionConfig(const Config & conf) {
     };
     ConfigDefault<std::string> strValues [] = {
         {&defaultUri, "dfs.default.uri", "hdfs://localhost:9000" },
+        {&defaultFS, "fs.defaultFS", "hdfs://localhost:8020" },
+        {&defaultName, "fs.default.name", "hdfs://localhost:8020" },
         {&rpcAuthMethod, "hadoop.security.authentication", "simple" },
         {&kerberosCachePath, "hadoop.security.kerberos.ticket.cache.path", "" },
         {&logSeverity, "dfs.client.log.severity", "INFO" },

--- a/src/common/SessionConfig.h
+++ b/src/common/SessionConfig.h
@@ -96,6 +96,14 @@ public:
         return defaultUri;
     }
 
+    const std::string & getDefaultFS() const {
+        return defaultFS;
+    }
+
+    const std::string & getDefaultName() const {
+        return defaultName;
+    }
+
     int32_t getDefaultReplica() const {
         return defaultReplica;
     }
@@ -327,6 +335,8 @@ public:
      * FileSystem configure
      */
     std::string defaultUri;
+    std::string defaultFS;
+    std::string defaultName;
     std::string kerberosCachePath;
     std::string logSeverity;
     int32_t defaultReplica;

--- a/src/common/XmlConfig.cpp
+++ b/src/common/XmlConfig.cpp
@@ -185,10 +185,12 @@ Config::Config(const char * p) :
     update(p);
 }
 
-void Config::update(const char * p) {
+  void Config::update(const char * p, bool clearPrevious) {
     xmlDocPtr doc; /* the resulting document tree */
     LIBXML_TEST_VERSION
-    kv.clear();
+    if (clearPrevious) {
+      kv.clear();
+    }
     path = p;
 
     if (access(path.c_str(), R_OK)) {

--- a/src/common/XmlConfig.h
+++ b/src/common/XmlConfig.h
@@ -57,7 +57,7 @@ public:
      * Parse the configure file.
      * @throw HdfsBadConfigFoumat
      */
-    void update(const char * path);
+    void update(const char * path, bool clearPrevious = true);
 
     /**
      * Get a string with given configure key.


### PR DESCRIPTION
Add the ability to read Hadoop configuration files from a build-time configured Hadoop system configuration directory, and to use the configured settings to establish HDFS connections using default values read from the Hadoop system configuration.