### PR TITLE
Fix prefix for pkgconfig

### DIFF
--- a/src/libhdfs3.pc.in
+++ b/src/libhdfs3.pc.in
@@ -1,4 +1,4 @@
-prefix=/usr
+prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 libdir=${prefix}/lib
 includedir=${prefix}/include


### PR DESCRIPTION
This small patch will fix the prefix path for libhdfs3.pc