### PR TITLE
Degrade log level on tolerable read error

### DIFF
--- a/src/client/InputStreamImpl.cpp
+++ b/src/client/InputStreamImpl.cpp
@@ -177,7 +177,7 @@ int64_t InputStreamImpl::readBlockLength(const LocatedBlock & b) {
             }
         } catch (const ReplicaNotFoundException & e) {
             std::string buffer;
-            LOG(LOG_ERROR,
+            LOG(INFO,
                 "InputStreamImpl: failed to get block visible length for Block: %s file %s from Datanode: %s\n%s",
                 b.toString().c_str(), path.c_str(), nodes[i].formatAddress().c_str(), GetExceptionDetail(e, buffer));
             LOG(INFO,
@@ -186,7 +186,7 @@ int64_t InputStreamImpl::readBlockLength(const LocatedBlock & b) {
             --replicaNotFoundCount;
         } catch (const HdfsIOException & e) {
             std::string buffer;
-            LOG(LOG_ERROR,
+            LOG(INFO,
                 "InputStreamImpl: failed to get block visible length for Block: %s file %s from Datanode: %s\n%s",
                 b.toString().c_str(), path.c_str(), nodes[i].formatAddress().c_str(), GetExceptionDetail(e, buffer));
             LOG(INFO,
@@ -202,6 +202,10 @@ int64_t InputStreamImpl::readBlockLength(const LocatedBlock & b) {
     if (replicaNotFoundCount == 0) {
         return 0;
     }
+
+    LOG(LOG_ERROR,
+        "InputStreamImpl: failed to get block visible length for Block: %s file %s from all Datanodes",
+        b.toString().c_str(), path.c_str());
 
     return -1;
 }


### PR DESCRIPTION
Out use case: write a file and sync it, read it from another process to fetch the latest data.
This use case causes much error logs. so we degrade the log level from ERROR to INFO and only log ERROR when all nodes are failed.